### PR TITLE
Android 14 crash 

### DIFF
--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -225,7 +225,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
 
    // Changes for registering reciever for Android 14
    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), RECEIVER_EXPORTED);
+      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), RECEIVER_NOT_EXPORTED);
     }else {
       mReactContext.registerReceiver(
               receiver,

--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -223,11 +223,16 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
       }
     };
 
-    mReactContext.registerReceiver(
-        receiver,
-        new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION),
-        null,
-        null);
+   // Changes for registering reciever for Android 14
+   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), RECEIVER_EXPORTED);
+    }else {
+      mReactContext.registerReceiver(
+              receiver,
+              new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION),
+              null,
+              null);
+    }
 
     DownloadableSubscription sub = DownloadableSubscription.forActivationCode(
         /* Passed from react side */


### PR DESCRIPTION
One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts

This crash happens when target Android SDK is set to 34 (Android 14)