### PR TITLE
[fix] Fixes Android build failing due to "Cannot Find Symbol"

### DIFF
--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -225,7 +225,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
 
    // Changes for registering reciever for Android 14
    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), RECEIVER_NOT_EXPORTED);
+      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), Context.RECEIVER_NOT_EXPORTED);
     }else {
       mReactContext.registerReceiver(
               receiver,


### PR DESCRIPTION
# Context
Apparently #64 introduced a bug when building Android apps as `RECEIVER_NOT_EXPORTED` was not being defined/imported correctly, causing the build to fail (as follows):

![image](https://github.com/odemolliens/react-native-sim-cards-manager/assets/53450202/584790dd-248c-47ea-9080-c4449f0b5485)

This PR fixes it by changing it to `Context.RECEIVER_NOT_EXPORTED`.