### PR TITLE
Create intent with FLAG_IMMUTABLE

### DIFF
--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -243,7 +243,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
         0,
         new Intent(ACTION_DOWNLOAD_SUBSCRIPTION),
         PendingIntent.FLAG_UPDATE_CURRENT |
-            PendingIntent.FLAG_MUTABLE);
+            PendingIntent.FLAG_IMMUTABLE);
 
     mgr.downloadSubscription(sub, true, callbackIntent);
   }


### PR DESCRIPTION
Setting `PendingIntent.FLAG_IMMUTABLE` instead of `PendingIntent.FLAG_MUTABLE` is correcting the issue https://github.com/odemolliens/react-native-sim-cards-manager/issues/73 on Android14.