### PR TITLE
Fix crashing on android < sdk 28

### DIFF
--- a/android/src/main/java/com/reactnativesimcardsmanager/EsimModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/EsimModule.java
@@ -20,8 +20,12 @@ public class EsimModule {
 
   @RequiresApi(api = Build.VERSION_CODES.P)
   public EuiccManager getMgr() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || mgr == null) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
       return null;
+    }
+
+    if (mgr != null) {
+      return mgr;
     }
 
     mgr = (EuiccManager) mReactContext.getSystemService(EUICC_SERVICE);

--- a/android/src/main/java/com/reactnativesimcardsmanager/EsimModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/EsimModule.java
@@ -1,0 +1,30 @@
+package com.reactnativesimcardsmanager;
+
+import static android.content.Context.EUICC_SERVICE;
+
+import android.os.Build;
+import android.telephony.euicc.EuiccManager;
+
+import androidx.annotation.RequiresApi;
+
+import com.facebook.react.bridge.ReactContext;
+
+public class EsimModule {
+  @RequiresApi(api = Build.VERSION_CODES.P)
+  private EuiccManager mgr;
+  private final ReactContext mReactContext;
+
+  EsimModule(ReactContext reactContext) {
+    mReactContext = reactContext;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.P)
+  public EuiccManager getMgr() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || mgr == null) {
+      return null;
+    }
+
+    mgr = (EuiccManager) mReactContext.getSystemService(EUICC_SERVICE);
+    return mgr;
+  }
+}

--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -82,7 +82,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
             number = manager.getPhoneNumber(subInfo.getSubscriptionId());
           } else {
             number = subInfo.getNumber();
-          } 
+          }
 
           CharSequence carrierName = subInfo.getCarrierName();
           String countryIso = subInfo.getCountryIso();
@@ -131,7 +131,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
     }
 
     if (accountHandle != null) {
-      Bundle extras = new Bundle();  
+      Bundle extras = new Bundle();
       extras.putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE,accountHandle);
       telecomManager.placeCall(uri, extras);
     }
@@ -140,8 +140,8 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
   @RequiresApi(api = Build.VERSION_CODES.P)
   @ReactMethod
   public void isEsimSupported(Promise promise) {
-    initMgr();
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && mgr != null) {
+      initMgr();
       promise.resolve(mgr.isEnabled());
     } else {
       promise.resolve(false);
@@ -178,7 +178,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
   @RequiresApi(api = Build.VERSION_CODES.P)
   @ReactMethod
   public void setupEsim(ReadableMap config, Promise promise) {
-    
+
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.P) {
       promise.reject("0", "EuiccManager is not available or before Android 9 (API 28)");
       return;
@@ -186,7 +186,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
 
     initMgr();
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && mgr != null && !mgr.isEnabled()) {
+    if (mgr != null && !mgr.isEnabled()) {
       promise.reject("1", "The device doesn't support a cellular plan (EuiccManager is not available)");
       return;
     }

--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -192,7 +192,7 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
           return;
         }
         int resultCode = getResultCode();
-        if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_RESOLVABLE_ERROR && mgr != null) {
+        if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_RESOLVABLE_ERROR && mEsimModule.getMgr() != null) {
           handleResolvableError(promise, intent);
         } else if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_OK) {
           promise.resolve(true);


### PR DESCRIPTION
Production users with older androids reported crashes (also related to https://github.com/odemolliens/react-native-sim-cards-manager/issues/82). Found that not referencing EuiccManager in a field in SimCardsManagerModule did the trick.

Verified the crashes and fix on android 5 device and emulator.