### PR TITLE
fix: use rootProject values correctly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,10 +18,10 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('SimCardsManager_compileSdkVersion', 33)
+    compileSdkVersion safeExtGet('compileSdkVersion', 33)
     defaultConfig {
-        minSdkVersion safeExtGet('SimCardsManager_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('SimCardsManager_targetSdkVersion', 33)
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 33)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
### Description

Take the values from the root project correctly, as the current root project (user app) should contain the ```SimCardsManager_XXXXX``` property, which doesn't exist.

The way it is now, the developer must have sdk 33 installed on his machine and his project can be sdk 35 / 36.