### PR TITLE
:bug: Fix Android BroadcastReceiver leak causing setupEsim to fail

### DIFF
--- a/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
+++ b/android/src/main/java/com/reactnativesimcardsmanager/SimCardsManagerModule.java
@@ -31,9 +31,10 @@ import java.util.List;
 @ReactModule(name = SimCardsManagerModule.NAME)
 public class SimCardsManagerModule extends ReactContextBaseJavaModule {
   public static final String NAME = "SimCardsManager";
-  private String ACTION_DOWNLOAD_SUBSCRIPTION = "download_subscription";
+  private static final String ACTION_DOWNLOAD_SUBSCRIPTION = "download_subscription";
   private ReactContext mReactContext;
   private EsimModule mEsimModule;
+  private BroadcastReceiver mDownloadReceiver;
 
   public SimCardsManagerModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -144,8 +145,6 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
   @RequiresApi(api = Build.VERSION_CODES.P)
   private void handleResolvableError(Promise promise, Intent intent) {
     try {
-      // Resolvable error, attempt to resolve it by a user action
-      // FIXME: review logic of resolve functions
       int resolutionRequestCode = 3;
       PendingIntent callbackIntent = PendingIntent.getBroadcast(
         mReactContext,
@@ -161,6 +160,15 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
     }
   }
 
+  private void unregisterReceiver() {
+    if (mDownloadReceiver != null) {
+      try {
+        mReactContext.unregisterReceiver(mDownloadReceiver);
+      } catch (IllegalArgumentException ignored) {}
+      mDownloadReceiver = null;
+    }
+  }
+
   private boolean checkCarrierPrivileges() {
     TelephonyManager telManager = (TelephonyManager) mReactContext.getSystemService(Context.TELEPHONY_SERVICE);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
@@ -173,7 +181,6 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
   @RequiresApi(api = Build.VERSION_CODES.P)
   @ReactMethod
   public void setupEsim(ReadableMap config, Promise promise) {
-
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.P) {
       promise.reject("0", "EuiccManager is not available or before Android 9 (API 28)");
       return;
@@ -189,56 +196,54 @@ public class SimCardsManagerModule extends ReactContextBaseJavaModule {
 //      return;
 //    }
 
-    BroadcastReceiver receiver = new BroadcastReceiver() {
+    unregisterReceiver();
+
+    mDownloadReceiver = new BroadcastReceiver() {
+      private boolean isHandled = false;
 
       @Override
       public void onReceive(Context context, Intent intent) {
-        boolean rejected = false;
-        String code = "";
-        String error = "";
-        if (!ACTION_DOWNLOAD_SUBSCRIPTION.equals(intent.getAction())) {
-          rejected = true;
-          code = "3";
-          error = "Can't setup eSim due to wrong Intent:" + intent.getAction() + " instead of "
-            + ACTION_DOWNLOAD_SUBSCRIPTION;
-        }
+        if (isHandled) return;
+
         int resultCode = getResultCode();
+        String action = intent != null ? intent.getAction() : null;
+
+        if (!ACTION_DOWNLOAD_SUBSCRIPTION.equals(action)) {
+          isHandled = true;
+          unregisterReceiver();
+          promise.reject("3",
+              "Can't setup eSim due to wrong Intent:" + action + " instead of "
+                  + ACTION_DOWNLOAD_SUBSCRIPTION);
+          return;
+        }
+
         if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_RESOLVABLE_ERROR && mEsimModule.getMgr() != null) {
           handleResolvableError(promise, intent);
-        } else if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_OK) {
+          return;
+        }
+
+        isHandled = true;
+        unregisterReceiver();
+
+        if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_OK) {
           promise.resolve(true);
         } else if (resultCode == EuiccManager.EMBEDDED_SUBSCRIPTION_RESULT_ERROR) {
-          // Embedded Subscription Error
-          rejected = true;
-          code = "2";
-          error = "EMBEDDED_SUBSCRIPTION_RESULT_ERROR - Can't add an Esim subscription";
+          promise.reject("2",
+              "EMBEDDED_SUBSCRIPTION_RESULT_ERROR - Can't add an Esim subscription");
         } else {
-          // Unknown Error
-          rejected = true;
-          code = "3";
-          error = "Can't add an Esim subscription due to unknown error, resultCode is:" + String.valueOf(resultCode);
-        }
-        // Unregister receiver
-        if (rejected) {
-          promise.reject(code, error);
-          mReactContext.unregisterReceiver(this);
+          promise.reject("3",
+              "Can't add an Esim subscription due to unknown error, resultCode is:" + String.valueOf(resultCode));
         }
       }
     };
 
-   // Changes for registering receiver for Android 14
-   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      mReactContext.registerReceiver(receiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), Context.RECEIVER_NOT_EXPORTED);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      mReactContext.registerReceiver(mDownloadReceiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), Context.RECEIVER_NOT_EXPORTED);
     } else {
-      mReactContext.registerReceiver(
-              receiver,
-              new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION),
-              null,
-              null);
+      mReactContext.registerReceiver(mDownloadReceiver, new IntentFilter(ACTION_DOWNLOAD_SUBSCRIPTION), null, null);
     }
 
     DownloadableSubscription sub = DownloadableSubscription.forActivationCode(
-        /* Passed from react side */
         config.getString("confirmationCode"));
 
     Intent intent = new Intent(ACTION_DOWNLOAD_SUBSCRIPTION).setPackage(mReactContext.getPackageName());


### PR DESCRIPTION
## Pull Request Description

**Context:**
This pull request fixes [#92](https://github.com/odemolliens/react-native-sim-cards-manager/issues/92) — `setupEsim` returns immediately with an error as soon as the LPA UI is launched on Android. This is the Android counterpart to the iOS fix in #91.

**Root Cause:**
The `BroadcastReceiver` registered in `setupEsim()` is never unregistered. When `setupEsim()` is called (or re-called), receivers accumulate. When the system broadcasts `EMBEDDED_SUBSCRIPTION_RESULT_RESOLVABLE_ERROR` (which triggers the LPA consent dialog), **all accumulated receivers** invoke `handleResolvableError` simultaneously. Since `startResolutionActivity` uses a single-use `IntentSender`, the first call succeeds but all subsequent calls crash with `SendIntentException`, causing the promise to reject immediately with `EMBEDDED_SUBSCRIPTION_RESULT_RESOLVABLE_ERROR - Can't setup eSim due to Activity error`.

**Main Changes:**

1. **Store receiver as instance variable (`mDownloadReceiver`)** instead of a local variable, enabling proper lifecycle management.

2. **Unregister previous receiver** at the start of each `setupEsim()` call via `unregisterReceiver()`, preventing accumulation.

3. **Add `isHandled` guard flag** inside the `BroadcastReceiver` to prevent duplicate `promise.resolve()`/`promise.reject()` calls if a broadcast is somehow delivered twice.

4. **Unregister receiver on all terminal states** (OK, ERROR, wrong action). The receiver is only kept alive for `RESOLVABLE_ERROR`, which requires waiting for the user consent resolution.

**Testing:**
Tested on a Samsung Galaxy A56 (Android 16, API 36) with eSIM provisioning — the LPA consent dialog now appears correctly and the promise resolves/rejects only after the actual installation outcome.